### PR TITLE
Repair bugs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ compiled
 docs
 ttt
 generate
+yarn.lock

--- a/src/lark.ts
+++ b/src/lark.ts
@@ -172,7 +172,10 @@ export class Lark {
     console.log(`[DEBUG] ${req.scope}#${req.api} ${method} ${url} req`, req)
 
     const headers = {} as { [key: string]: string }
-    if (req.need_tenant_accessToken) {
+
+    if (req.need_user_accessToken && !!this.verificationToken) {
+      headers['Authorization'] = `Bearer ${this.verificationToken}`
+    } else if (req.need_tenant_accessToken) {
       const { data } = await this.auth.getTenantAccessToken()
       headers['Authorization'] = `Bearer ${data.token}`
     } else if (req.need_app_accessToken) {


### PR DESCRIPTION
Summary:
Apis with user access token is not implemented.
Though `need_user_accessToken` and `verificationToken` is well-defined, they are not be used to implement anything.
Now, judgement is added in `lark.ts` and user_access_token could work.